### PR TITLE
update out-dir to new terminology dist-dir for npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "source": "./index.html",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "parcel index.html --out-dir ./.dist",
+    "start": "parcel index.html --dist-dir ./.dist",
     "init": "node ./scripts/init.js",
     "prepare-nodejs": "cd www/nodejs-project && TARGET_ARCH=arm64 TARGET_PLATFORM=android npm install",
     "lint": "eslint --fix src/ || exit 0",


### PR DESCRIPTION
the npm start script is using a parameter that was used on an older version. "out-dir" is now "dist-dir" after this change you can run `npm run start` without error.