### PR TITLE
add FUNDING.yml file so that rfparty-mobile can display a sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [sevenbitbyte]


### PR DESCRIPTION
Saw that you accept GitHub sponsors on YouTube. You may want to consider adding a FUNDING.yml file and enabling the sponsorship button on this repo. 

see: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository

note: double check I got your username right.